### PR TITLE
Fix intallation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Copy `C:\Windows\System32\WinMetadata` from a Windows computer to `license_viola
 Install it
 
 ```
-./affinity.sh ./affinity-designer-msi-2.3.0.exe
+./affinity.sh wine ./affinity-designer-msi-2.3.0.exe
 ```
 
 Run it


### PR DESCRIPTION
trying to run it without noticing that `wine` is missing results in a somewhat confusing permission error