### PR TITLE
Add vcrun2022 package to prevent Affinity Photo from crashing after PNG export

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ source "$selfpath/affinity.sh"
 WINEDLLOVERRIDES="mscoree=" wineboot --init
 # FIXME: fix in wine packaging
 wine msiexec /i "$wineEnv/share/wine/mono/wine-mono-9.4.0-x86.msi"
-winetricks -q dotnet48 corefonts mfc140
+winetricks -q dotnet48 corefonts mfc140 vcrun2022
 wine winecfg -v win11
 # grab from a real windows computer
 cp -r "$selfpath/license_violations/WinMetadata" "$WINEPREFIX/drive_c/windows/system32/"


### PR DESCRIPTION
Affinity Photo experiences the same crash-after-export issue that Designer did, however the package that fixed the issue for Designer did not fix it for Photo. User Pacific on the forum [stated](https://forum.affinity.serif.com/?app=core&module=system&controller=content&do=find&content_class=forums_Topic&content_id=182758&content_commentid=1369553) that the `vcrun2022` fixes the issue.

I've tested it on my install and it does indeed fix the export issue for me, with no issues saving the project file that I've observed as reported by other users on the forum. I'm not sure if/where any prior discussion of `vcrun2022` fixing the export issue is on the forum, maybe there's more technical info somewhere there that is worth looking into, I unfortunately don't have enough time to run down that rabbit hole. 